### PR TITLE
Autoconf 2.68 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,10 +31,10 @@ AC_MSG_CHECKING(whether compiler supports C++11 cstdatomic)
 
 OLD_CXXFLAGS="$CXXFLAGS"
 CXXFLAGS="$CXXFLAGS -std=c++0x"
-AC_COMPILE_IFELSE([
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([
 #include <cstdatomic>
 int main() {}
-], [
+])], [
      AC_MSG_RESULT(yes)
      has_cstdatomic=yes
    ],


### PR DESCRIPTION
Without this change, I get the following errors when trying to run autoconf on Ubuntu 11.10:

configure.ac:XX: warning: AC_LANG_CONFTEST: no AC_LANG_SOURCE call detected in body
../../lib/autoconf/lang.m4:194: AC_LANG_CONFTEST is expanded from...
../../lib/autoconf/general.m4:2591: _AC_COMPILE_IFELSE is expanded from...
../../lib/autoconf/general.m4:2607: AC_COMPILE_IFELSE is expanded from...
configure.ac:XX: the top level

See http://www.flameeyes.eu/autotools-mythbuster/forwardporting/autoconf.html and http://www.mail-archive.com/bug-autoconf@gnu.org/msg03052.html for details.
