### PR TITLE
Fix for memory corruption and segfaults.

### DIFF
--- a/src/Database/LevelDB.hs
+++ b/src/Database/LevelDB.hs
@@ -436,6 +436,7 @@ withCReadOptions opts f = do
 
 throwIfErr :: String -> ErrPtr -> (ErrPtr -> IO a) -> IO a
 throwIfErr s err_ptr f = do
+    poke err_ptr nullPtr
     res  <- f err_ptr
     erra <- peek err_ptr
     when (erra /= nullPtr) $ do


### PR DESCRIPTION
See convention #3 at http://code.google.com/p/leveldb/source/browse/include/leveldb/c.h
The *errptr must be NULL, but previously that was not always so, because Haskell alloca, while allocates memory, does not zero-fill it.
