### PR TITLE
Fix build of 'features' example

### DIFF
--- a/examples/features.hs
+++ b/examples/features.hs
@@ -6,6 +6,7 @@ module Main where
 
 import Control.Monad
 import Control.Monad.IO.Class       (liftIO)
+import Control.Monad.Trans.Resource (release)
 import Data.ByteString.Char8 hiding (take)
 import Data.Default
 import Prelude               hiding (putStrLn)


### PR DESCRIPTION
The 'features.hs' example failed to build on my system (GHC 7.4.1, resourcet-0.4.7). This patch fixes the build.
