### PR TITLE
RFC: Zero-copy ByteString creation

### DIFF
--- a/src/Database/LevelDB.hs
+++ b/src/Database/LevelDB.hs
@@ -83,12 +83,12 @@ import Control.Monad                      (liftM, when)
 import Control.Monad.IO.Class             (liftIO)
 import Control.Monad.Trans.Resource
 import Data.ByteString                    (ByteString)
-import Data.ByteString.Internal           (ByteString(..))
+import Data.ByteString.Internal           (ByteString(..), c_free_finalizer)
 import Data.Default
 import Data.Maybe                         (catMaybes)
 import Foreign
 import Foreign.C.Error                    (throwErrnoIfNull)
-import Foreign.C.String                   (withCString, peekCString)
+import Foreign.C.String                   (CStringLen, withCString, peekCString)
 import Foreign.C.Types                    (CSize, CInt)
 
 import Database.LevelDB.Base
@@ -378,9 +378,7 @@ getProperty (DB db_ptr) p = liftIO $
         val_ptr <- c_leveldb_property_value db_ptr prop_ptr
         if val_ptr == nullPtr
             then return Nothing
-            else do res <- Just <$> BS.packCString val_ptr
-                    free val_ptr
-                    return res
+            else Just <$> BU.unsafePackMallocCString val_ptr
 
     where
         prop (NumFilesAtLevel i) = "leveldb.num-files-at-level" ++ show i
@@ -461,12 +459,15 @@ get (DB db_ptr) opts key = do
             vlen <- peek vlen_ptr
             if val_ptr == nullPtr
                 then return Nothing
-                else do
-                    fp <- newForeignPtr finalizerFree (castPtr val_ptr)
-                    return $ Just $ PS fp 0 (cSizeToInt vlen)
+                else Just <$> unsafePackMallocCStringLen (val_ptr, cSizeToInt vlen)
 
     release rk
     return res
+  where
+    unsafePackMallocCStringLen :: CStringLen -> IO ByteString
+    unsafePackMallocCStringLen (cstr, len) = do
+        fp <- newForeignPtr c_free_finalizer (castPtr cstr)
+        return $! PS fp 0 len
 
 -- | Delete a key/value pair
 delete :: MonadResource m => DB -> WriteOptions -> ByteString -> m ()
@@ -634,7 +635,7 @@ iterKey iter = do
                     then return Nothing
                     else do
                         klen <- peek len_ptr
-                        Just <$> BS.packCStringLen (key_ptr, cSizeToInt klen)
+                        Just <$> BU.unsafePackCStringLen (key_ptr, cSizeToInt klen)
 
 -- | Return the value for the current entry if the iterator is currently
 -- positioned at an entry, ie. 'iterValid'.
@@ -653,7 +654,7 @@ iterValue iter = do
                     then return Nothing
                     else do
                         vlen <- peek len_ptr
-                        Just <$> BS.packCStringLen (val_ptr, cSizeToInt vlen)
+                        Just <$> BU.unsafePackCStringLen (val_ptr, cSizeToInt vlen)
 
 -- | Check for errors
 --
@@ -875,8 +876,8 @@ mkCompareFun cmp = cmp'
 
     where
         cmp' _ a alen b blen = do
-            a' <- BS.packCStringLen (a, fromInteger . toInteger $ alen)
-            b' <- BS.packCStringLen (b, fromInteger . toInteger $ blen)
+            a' <- BU.unsafePackCStringLen (a, fromInteger . toInteger $ alen)
+            b' <- BU.unsafePackCStringLen (b, fromInteger . toInteger $ blen)
             return $ case cmp a' b' of
                          EQ ->  0
                          GT ->  1
@@ -912,15 +913,15 @@ mkCreateFilterFun f = f'
             poke flen (fromIntegral . BS.length $ res)
             BS.useAsCString res $ \cstr -> return cstr
 
-        bstr (x,len) = BS.packCStringLen (x, fromInteger . toInteger $ len)
+        bstr (x,len) = BU.unsafePackCStringLen (x, fromInteger . toInteger $ len)
 
 mkKeyMayMatchFun :: (ByteString -> ByteString -> Bool) -> KeyMayMatchFun
 mkKeyMayMatchFun g = g'
 
     where
         g' _ k klen f flen = do
-            k' <- BS.packCStringLen (k, fromInteger . toInteger $ klen)
-            f' <- BS.packCStringLen (f, fromInteger . toInteger $ flen)
+            k' <- BU.unsafePackCStringLen (k, fromInteger . toInteger $ klen)
+            f' <- BU.unsafePackCStringLen (f, fromInteger . toInteger $ flen)
             return . boolToNum $ g k' f'
 
 

--- a/src/Database/LevelDB.hs
+++ b/src/Database/LevelDB.hs
@@ -462,9 +462,8 @@ get (DB db_ptr) opts key = do
             if val_ptr == nullPtr
                 then return Nothing
                 else do
-                    res' <- Just <$> BS.packCStringLen (val_ptr, cSizeToInt vlen)
-                    free val_ptr
-                    return res'
+                    fp <- newForeignPtr finalizerFree (castPtr val_ptr)
+                    return $ Just $ PS fp 0 (cSizeToInt vlen)
 
     release rk
     return res

--- a/src/Database/LevelDB.hs
+++ b/src/Database/LevelDB.hs
@@ -456,10 +456,11 @@ get (DB db_ptr) opts key = do
         alloca                       $ \vlen_ptr        -> do
             val_ptr <- throwIfErr "get" $
                 c_leveldb_get db_ptr opts_ptr key_ptr (intToCSize klen) vlen_ptr
-            vlen <- peek vlen_ptr
             if val_ptr == nullPtr
                 then return Nothing
-                else Just <$> unsafePackMallocCStringLen (val_ptr, cSizeToInt vlen)
+                else do
+                    vlen <- peek vlen_ptr
+                    Just <$> unsafePackMallocCStringLen (val_ptr, cSizeToInt vlen)
 
     release rk
     return res


### PR DESCRIPTION
Hi,

This is mainly a request-for-comments & check whether there's any interest in this, not a real pull request (for now).

Currently the library uses `packCStringLen` to turn strings returned from the LevelDB API into `ByteString`. This is an *O(n)* operation in the length of the string (it results in a `memcpy` of the string from C heap into Haskell's GC'ed heap).

This can have quite some impact when dealing with large values.

I noticed the library uses `unsafeUseAsCStringLen` to pass `ByteString` values to the LevelDB procedures, which doesn't incur any copying, so thought it'd make sense to do the reverse as well.

I think this has one drawback: the values won't show up in memory statistics & profiling, since they're outside the Haskell-managed heap.

I chose to implement the change as contained in this 69c6ff93894 instead of using `Data.ByteString.Unsafe.unsafePackCStringFinalizer`, since the latter uses `Foreign.Concurrent.newForeignPtr` to create a `ForeignPtr`, and its documentation says:

> There is no guarantee of promptness, and **in fact there is no guarantee that the finalizer will eventually run at all**.

(emphasis mine) which makes me kinda nervous. Might want to check with @dons, @dcoutts or someone else more knowledgeable than me :smile: