### PR TITLE
Bug: Fix 'fillCache' option setting

### DIFF
--- a/src/Database/LevelDB.hs
+++ b/src/Database/LevelDB.hs
@@ -827,7 +827,7 @@ mkCReadOptions ReadOptions{..} = do
         $ boolToNum verifyCheckSums
 
     liftIO
-        $ c_leveldb_readoptions_set_verify_checksums opts_ptr
+        $ c_leveldb_readoptions_set_fill_cache opts_ptr
         $ boolToNum fillCache
 
     maybeSetSnapshot opts_ptr useSnapshot


### PR DESCRIPTION
Instead of setting the 'fill_cache' option, 'set_verify_checksum' was
called incorrectly using the 'fillCache' setting.
