### PR TITLE
Remove unneeded dependencies on snappy and stdc++.

### DIFF
--- a/leveldb-haskell.cabal
+++ b/leveldb-haskell.cabal
@@ -64,7 +64,7 @@ library
 
   hs-source-dirs:   src
 
-  extra-libraries:  leveldb, snappy, stdc++
+  extra-libraries:  leveldb
 
 executable leveldb-example-comparator
   main-is:          comparator.hs


### PR DESCRIPTION
It looks like these dependencies aren't used now. Are they a remnant from the time leveldb was bundled with the bindings?
