### PR TITLE
Update leveldb project urls

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,5 @@
 This library provides Haskell bindings to
-[LevelDB](http://leveldb.googlecode.com)
+[LevelDB](https://github.com/google/leveldb)
 
 [![Build Status](https://secure.travis-ci.org/kim/leveldb-haskell.png)](http://travis-ci.org/kim/leveldb-haskell)
 
@@ -9,7 +9,7 @@ Prerequisites:
 
 * [GHC 7.*](http://www.haskell.org/ghc)
 * [Cabal](http://www.haskell.org/cabal), version 1.3 or higher
-* [LevelDB](http://code.google.com/p/leveldb)
+* [LevelDB](https://github.com/google/leveldb)
 * Optional: [Snappy](http://code.google.com/p/snappy),
   if compression support is desired
 

--- a/leveldb-haskell.cabal
+++ b/leveldb-haskell.cabal
@@ -14,7 +14,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 tested-with:         GHC == 7.4.2, GHC == 7.6.4, GHC == 7.8.3
 description:
-    From <http://leveldb.googlecode.com>:
+    From <http://code.google.com/p/snappy>:
     .
     LevelDB is a fast key-value storage library written at Google that provides
     an ordered mapping from string keys to string values.


### PR DESCRIPTION
Dear author,

Google has announced the end of their code hosting, the leveldb project has moved.

Please consider updating the urls to the new github url proposed on their website https://code.google.com/p/leveldb/