### PR TITLE
Compiles with latest version of exceptions package

### DIFF
--- a/leveldb-haskell.cabal
+++ b/leveldb-haskell.cabal
@@ -54,7 +54,7 @@ library
   build-depends:    base >= 3 && < 5
                   , bytestring
                   , data-default
-                  , exceptions == 0.6.*
+                  , exceptions >= 0.6
                   , filepath
                   , resourcet > 0.3.2
                   , transformers
@@ -162,7 +162,7 @@ test-suite leveldb-properties
                   , bytestring
                   , data-default
                   , directory
-                  , exceptions       == 0.6.*
+                  , exceptions       >= 0.6
                   , mtl
                   , leveldb-haskell
                   , QuickCheck       == 2.7.*


### PR DESCRIPTION
Hi All,

I updated the cabal config so that this package will compile with exceptions 0.6 and greater.

Thanks,
Randi