### PR TITLE
fix for Windows

### DIFF
--- a/leveldb-haskell.cabal
+++ b/leveldb-haskell.cabal
@@ -63,6 +63,8 @@ library
 
   hs-source-dirs:   src
 
+  if os(mingw32)
+    extra-libraries: libstdc++-6
   extra-libraries:  leveldb
 
 executable leveldb-example-comparator


### PR DESCRIPTION
I got `leveldb-haskell` to work in Windows, with these instructions: https://github.com/lamdu/lamdu/blob/master/doc/Build.md#windows

It appears that on Windows, GHC needs the `libstdc++-6` dependency to be specified, otherwise it fails in either final linkage or when using `TemplateHaskell` in packages which depend on `leveldb-haskell`.