### PR TITLE
Fix tests on base ≥ 4.15

### DIFF
--- a/test/Test/Streaming.hs
+++ b/test/Test/Streaming.hs
@@ -14,7 +14,7 @@ import qualified Data.ByteString            as BS
 import           Data.ByteString.Char8      (ByteString, singleton, unpack)
 import           Data.Default
 import           Data.Foldable              (foldMap)
-import           Data.List
+import           Data.List                  hiding (singleton)
 import           Data.Monoid
 import           Database.LevelDB.Base
 import           Database.LevelDB.Internal  (unsafeClose)


### PR DESCRIPTION
`singleton` became ambiguous since base 4.15 added Data.List.singleton.