### PR TITLE
Fix tests on mtl ≥ 2.3

### DIFF
--- a/test/Test/Streaming.hs
+++ b/test/Test/Streaming.hs
@@ -7,6 +7,7 @@
 module Test.Streaming (tests) where
 
 import           Control.Applicative        hiding (empty)
+import           Control.Monad              (liftM2, foldM)
 import           Control.Monad.Catch
 import           Control.Monad.Identity
 import           Control.Monad.IO.Class


### PR DESCRIPTION
mtl stopped (re)exporting some functions, causing a build error.