### PR TITLE
Fix free calls

### DIFF
--- a/src/Database/LevelDB/Base.hs
+++ b/src/Database/LevelDB/Base.hs
@@ -66,7 +66,7 @@ import           Control.Monad.IO.Class   (MonadIO (liftIO))
 import           Data.ByteString          (ByteString)
 import           Data.ByteString.Internal (ByteString (..))
 import           Data.IORef
-import           Foreign                  hiding (void)
+import           Foreign                  hiding (free, void)
 import           Foreign.C.String         (withCString)
 
 import           Database.LevelDB.C
@@ -135,7 +135,7 @@ getProperty (DB db_ptr _ _) p = liftIO $
         if val_ptr == nullPtr
             then return Nothing
             else do res <- Just <$> BS.packCString val_ptr
-                    free val_ptr
+                    c_leveldb_free val_ptr
                     return res
   where
     prop (NumFilesAtLevel i) = "leveldb.num-files-at-level" ++ show i
@@ -214,7 +214,7 @@ get (DB db_ptr _ _) opts key = liftIO $ withCReadOpts opts $ \opts_ptr ->
             then return Nothing
             else do
                 res' <- Just <$> BS.packCStringLen (val_ptr, cSizeToInt vlen)
-                free val_ptr
+                c_leveldb_free val_ptr
                 return res'
 
 -- | Delete a key/value pair.

--- a/src/Database/LevelDB/C.hsc
+++ b/src/Database/LevelDB/C.hsc
@@ -14,8 +14,8 @@
 module Database.LevelDB.C where
 
 import Foreign
-import Foreign.C.Types
 import Foreign.C.String
+import Foreign.C.Types
 
 #include <leveldb/c.h>
 
@@ -354,10 +354,17 @@ foreign import ccall safe "leveldb/c.h leveldb_cache_create_lru"
 foreign import ccall safe "leveldb/c.h leveldb_cache_destroy"
   c_leveldb_cache_destroy :: CachePtr -> IO ()
 
+--
+-- Utility
+--
 
---
--- Version
---
+-- Calls free(ptr).
+-- REQUIRES: ptr was malloc()-ed and returned by one of the routines
+-- in this file.  Note that in certain cases (typically on Windows), you
+-- may need to call this routine instead of free(ptr) to dispose of
+-- malloc()-ed memory returned by this library. */
+foreign import ccall safe "leveldb/c.h leveldb_free"
+  c_leveldb_free :: Ptr a -> IO ()
 
 foreign import ccall unsafe "leveldb/c.h leveldb_major_version"
   c_leveldb_major_version :: IO CInt


### PR DESCRIPTION
I found that this library was crashing on Windows due to using the incorrect `free` when I called the `get` function.

As the LevelDB header file says (see [here](https://github.com/google/leveldb/blob/ac691084fdc5546421a55b25e7653d450e5a25fb/include/leveldb/c.h#L253C1-L258)), it's important to free the memory returned from LevelDB using the same allocator that produced it. For this reason, LevelDB provides the C `leveldb_free` function.

I don't think this causes problems on Linux (although maybe there are subtle security implications?). But the `free` from [Foreign.Alloc.Marshal](https://hackage.haskell.org/package/base-4.21.0.0/docs/Foreign-Marshal-Alloc.html#v:free) in Haskell on Windows must use a different allocator because I always get an immediate crash.